### PR TITLE
online users detection and dynamic dmChannel name

### DIFF
--- a/dist/resolvers/team.js
+++ b/dist/resolvers/team.js
@@ -1,4 +1,4 @@
-"use strict";
+'use strict';
 
 Object.defineProperty(exports, "__esModule", {
   value: true
@@ -6,18 +6,18 @@ Object.defineProperty(exports, "__esModule", {
 
 var _extends = Object.assign || function (target) { for (var i = 1; i < arguments.length; i++) { var source = arguments[i]; for (var key in source) { if (Object.prototype.hasOwnProperty.call(source, key)) { target[key] = source[key]; } } } return target; };
 
-var _formatErrors = require("../formatErrors");
+var _formatErrors = require('../formatErrors');
 
 var _formatErrors2 = _interopRequireDefault(_formatErrors);
 
-var _permissions = require("../permissions");
+var _permissions = require('../permissions');
 
 function _interopRequireDefault(obj) { return obj && obj.__esModule ? obj : { default: obj }; }
 
 exports.default = {
   Query: {
     getTeamMembers: _permissions.requireAuth.createResolver(async (parent, { teamId }, { models }) => {
-      return models.sequelize.query("select * from users as u join members as m on m.user_id = u.id where m.team_id=?", { replacements: [teamId], model: models.User, raw: true });
+      return models.sequelize.query('select * from users as u join members as m on m.user_id = u.id where m.team_id=?', { replacements: [teamId], model: models.User, raw: true });
     })
   },
   Mutation: {
@@ -26,7 +26,7 @@ exports.default = {
         const response = await models.sequelize.transaction(async transaction => {
           const team = await models.Team.create(_extends({}, args), { transaction });
           await models.Channel.create({
-            name: "general",
+            name: 'general',
             public: true,
             teamId: team.id
           }, { transaction });
@@ -61,8 +61,8 @@ exports.default = {
           return {
             ok: false,
             errors: [{
-              path: "email",
-              message: "You cannot add member to the team"
+              path: 'email',
+              message: 'You cannot add member to the team'
             }]
           };
         }
@@ -70,8 +70,8 @@ exports.default = {
           return {
             ok: false,
             errors: [{
-              path: "email",
-              message: "Could not find user with this email"
+              path: 'email',
+              message: 'Could not find user with this email'
             }]
           };
         }
@@ -90,7 +90,7 @@ exports.default = {
   },
   Team: {
     channels: async ({ id }, args, { channelLoader }) => channelLoader.load(id),
-    directMessageMembers: async ({ id }, args, { models, user }) => models.sequelize.query("select distinct on (u.id) u.id, u.username from users as u join direct_messages as dm on (u.id = dm.sender_id or u.id = dm.receiver_id) where (:currentUserId = dm.sender_id or :currentUserId = dm.receiver_id) and dm.team_id = :teamId", {
+    directMessageMembers: async ({ id }, args, { models, user }) => models.sequelize.query('select distinct on (u.id) u.id, u.username from users as u join direct_messages as dm on (u.id = dm.sender_id or u.id = dm.receiver_id) where (:currentUserId = dm.sender_id or :currentUserId = dm.receiver_id) and dm.team_id = :teamId', {
       replacements: { currentUserId: user.id, teamId: id },
       model: models.User,
       raw: true

--- a/dist/resolvers/user.js
+++ b/dist/resolvers/user.js
@@ -43,6 +43,8 @@ exports.default = {
       }
     },
 
-    login: (parent, { email, password }, { models, SECRET, SECRET2 }) => (0, _auth.tryLogin)(email, password, models, SECRET, SECRET2)
+    login: async (parent, { email, password }, { models, SECRET, SECRET2 }) => {
+      return (0, _auth.tryLogin)(email, password, models, SECRET, SECRET2);
+    }
   }
 };

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "graphql-redis-subscriptions": "^2.1.1",
     "graphql-subscriptions": "0.5.4",
     "graphql-tools": "2.2.1",
+    "immutable": "^4.0.0-rc.12",
     "jsonwebtoken": "^8.5.1",
     "lodash": "^4.17.14",
     "merge-graphql-schemas": "1.1.4",

--- a/src/resolvers/channel.js
+++ b/src/resolvers/channel.js
@@ -41,7 +41,9 @@ export default {
           }
         });
 
-        const name = users.map(user => user.username).join(", ");
+        let name = user.username + ", ";
+
+        name += users.map(user => user.username).join(", ");
 
         const channelId = await models.sequelize.transaction(
           async transaction => {

--- a/src/resolvers/team.js
+++ b/src/resolvers/team.js
@@ -109,8 +109,8 @@ export default {
     )
   },
   Team: {
-    channels: async ({ id }, args, { channelLoader }) => channelLoader.load(id),
-    directMessageMembers: async ({ id }, args, { models, user }) =>
+    channels: ({ id }, args, { channelLoader }) => channelLoader.load(id),
+    directMessageMembers: ({ id }, args, { models, user }) =>
       models.sequelize.query(
         "select distinct on (u.id) u.id, u.username from users as u join direct_messages as dm on (u.id = dm.sender_id or u.id = dm.receiver_id) where (:currentUserId = dm.sender_id or :currentUserId = dm.receiver_id) and dm.team_id = :teamId",
         {

--- a/src/resolvers/user.js
+++ b/src/resolvers/user.js
@@ -20,7 +20,11 @@ export default {
     ),
     allUsers: (parent, args, { models }) => models.User.findAll(),
     getUser: (parent, { userId }, { models }) =>
-      models.User.findOne({ where: { id: userId } })
+      models.User.findOne({ where: { id: userId } }),
+    onlineUsers: (parent, args, { onlineUsers }) => {
+      // return onlineUsers.filter(user => Date.now() - user.last_seen < 60000);
+      return onlineUsers;
+    }
   },
   Mutation: {
     register: async (parent, args, { models }) => {
@@ -38,7 +42,8 @@ export default {
       }
     },
 
-    login: (parent, { email, password }, { models, SECRET, SECRET2 }) =>
-      tryLogin(email, password, models, SECRET, SECRET2)
+    login: async (parent, { email, password }, { models, SECRET, SECRET2 }) => {
+      return tryLogin(email, password, models, SECRET, SECRET2);
+    }
   }
 };

--- a/src/schema/user.js
+++ b/src/schema/user.js
@@ -12,6 +12,12 @@ type Query {
   me: User!
   allUsers: [User!]!
   getUser(userId: Int!): User
+  onlineUsers: [onlineUser!]
+}
+
+type onlineUser {
+  username: String!
+  last_seen: String!
 }
 
 type RegisterResponse {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2250,6 +2250,11 @@ ignore-walk@^3.0.1:
   dependencies:
     minimatch "^3.0.4"
 
+immutable@^4.0.0-rc.12:
+  version "4.0.0-rc.12"
+  resolved "https://registry.yarnpkg.com/immutable/-/immutable-4.0.0-rc.12.tgz#ca59a7e4c19ae8d9bf74a97bdf0f6e2f2a5d0217"
+  integrity sha512-0M2XxkZLx/mi3t8NVwIm1g8nHoEmM9p9UBl/G9k4+hm0kBgOVdMV/B3CY5dQ8qG8qc80NN4gDV4HQv6FTJ5q7A==
+
 import-lazy@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/import-lazy/-/import-lazy-2.1.0.tgz#05698e3d45c88e8d7e9d92cb0584e77f096f3e43"


### PR DESCRIPTION
Build user online detection feature with graphql-subscription-ws:
- push user connected subscription server to an array (called onlineUsers) and return onlineUsers so that it can be used as a context in other resolvers.
- render the onlineUsers in the frontend based on last_seen property. (last_seen < 60000 mils is online and is offline in the other hand).

Rename the direct message group's name based-on the user (who create it) and other members.
- create the name property with initial value is the user creating it
- then add the follow on members

